### PR TITLE
feat/#19 Implement github webhook validation

### DIFF
--- a/src/main/java/GitHubIntegration.java
+++ b/src/main/java/GitHubIntegration.java
@@ -1,5 +1,3 @@
-import com.sun.net.httpserver.Headers;
-
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 import java.security.InvalidKeyException;

--- a/src/main/java/GitHubIntegration.java
+++ b/src/main/java/GitHubIntegration.java
@@ -1,0 +1,60 @@
+import com.sun.net.httpserver.Headers;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.HexFormat;
+
+/**
+ * Contains methods for handling integration towards GitHub.
+ */
+public class GitHubIntegration {
+
+    private final String HMAC_SHA256 = "HmacSHA256";
+    private final String WEBHOOK_SIGNATURE_PREFIX = "sha256=";
+
+    /**
+     * Validates a webhook request
+     * @param body The body of the request
+     * @param signatureHeader The contens of header X-Hub-Signature-256
+     * @param secret The secret specified in the webhook
+     * @return True if the signature is valid, false otherwise
+     * @throws NoSuchAlgorithmException if the hardcoded algorithm is invalid
+     * @throws InvalidKeyException if the hardcoded secret key spec is invalid
+     * @throws IllegalArgumentException if the signature is incorrectly formatted
+     */
+    public boolean validateWebhook(String body, String signatureHeader, String secret)
+            throws NoSuchAlgorithmException, InvalidKeyException, IllegalArgumentException
+    {
+        if (!signatureHeader.startsWith(WEBHOOK_SIGNATURE_PREFIX)) {
+            throw new IllegalArgumentException("The signature does not start with \""+WEBHOOK_SIGNATURE_PREFIX+"\"");
+        }
+        String signaturePart = signatureHeader.substring(WEBHOOK_SIGNATURE_PREFIX.length());;
+        byte[] signature;
+        try {
+            signature = HexFormat.of().parseHex(signaturePart);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("The signature header is not hexadecimal", ex);
+        }
+
+        Mac mac;
+        try {
+            mac = Mac.getInstance(HMAC_SHA256);
+        } catch (NoSuchAlgorithmException ex){
+            throw new NoSuchAlgorithmException("Could not validate webhook, the hardcoded algorithm is invalid", ex);
+        }
+
+        var secretKey = new SecretKeySpec(secret.getBytes(), HMAC_SHA256);
+        try {
+            mac.init(secretKey);
+        } catch (InvalidKeyException ex) {
+            throw new InvalidKeyException("Could not validate webhook, Mac object could not accept secret key", ex);
+        }
+
+        var expected = mac.doFinal(body.getBytes());
+
+        return Arrays.equals(expected, signature);
+    }
+}

--- a/src/main/java/GitHubIntegration.java
+++ b/src/main/java/GitHubIntegration.java
@@ -28,6 +28,7 @@ public class GitHubIntegration {
     public boolean validateWebhook(String body, String signatureHeader, String secret)
             throws NoSuchAlgorithmException, InvalidKeyException, IllegalArgumentException
     {
+        // Check that the signature formatting and encoding is valid
         if (!signatureHeader.startsWith(WEBHOOK_SIGNATURE_PREFIX)) {
             throw new IllegalArgumentException("The signature does not start with \""+WEBHOOK_SIGNATURE_PREFIX+"\"");
         }
@@ -39,13 +40,13 @@ public class GitHubIntegration {
             throw new IllegalArgumentException("The signature header is not hexadecimal", ex);
         }
 
+        // Initialize Mac object
         Mac mac;
         try {
             mac = Mac.getInstance(HMAC_SHA256);
         } catch (NoSuchAlgorithmException ex){
             throw new NoSuchAlgorithmException("Could not validate webhook, the hardcoded algorithm is invalid", ex);
         }
-
         var secretKey = new SecretKeySpec(secret.getBytes(), HMAC_SHA256);
         try {
             mac.init(secretKey);
@@ -53,8 +54,8 @@ public class GitHubIntegration {
             throw new InvalidKeyException("Could not validate webhook, Mac object could not accept secret key", ex);
         }
 
+        // Generate and compare HMAC
         var expected = mac.doFinal(body.getBytes());
-
         return Arrays.equals(expected, signature);
     }
 }

--- a/src/main/java/GitHubIntegration.java
+++ b/src/main/java/GitHubIntegration.java
@@ -10,8 +10,8 @@ import java.util.HexFormat;
  */
 public class GitHubIntegration {
 
-    private final String HMAC_SHA256 = "HmacSHA256";
-    private final String WEBHOOK_SIGNATURE_PREFIX = "sha256=";
+    private static final String HMAC_SHA256 = "HmacSHA256";
+    private static final String WEBHOOK_SIGNATURE_PREFIX = "sha256=";
 
     /**
      * Validates a webhook request

--- a/src/test/java/GitHubIntegrationTest.java
+++ b/src/test/java/GitHubIntegrationTest.java
@@ -1,0 +1,48 @@
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.HexFormat;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class GitHubIntegrationTest {
+    String webhookBody;
+    String webhookSecret;
+    String webhookHMAC;
+
+    @BeforeEach
+    void setUp(){
+        webhookBody = "Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. It has survived not only five centuries, but also the leap into electronic typesetting, remaining essentially unchanged. It was popularised in the 1960s with the release of Letraset sheets containing Lorem Ipsum passages, and more recently with desktop publishing software like Aldus PageMaker including versions of Lorem Ipsum.";
+        webhookSecret = "pX%[?w2M:9zrx-mBp\"G8WV-";
+        webhookHMAC = "sha256=399aff558b24178c98e6e07dfbecd1a6f34c8874d331ec3eae902d3711b6a5a5";
+    }
+
+    @Test
+    void testValidateWebhookTrue() {
+        var gh = new GitHubIntegration();
+        var result = assertDoesNotThrow(() -> gh.validateWebhook(webhookBody, webhookHMAC, webhookSecret), "Validating the webhook should return true/false");
+        assertTrue(result, "The webhook should be valid");
+    }
+
+    @Test
+    void testValidateWebhookIncorrectSecret() {
+        var gh = new GitHubIntegration();
+        webhookSecret = "sX%[?w2M:9zrx-mBp\"G8WV-";
+        var result = assertDoesNotThrow(() -> gh.validateWebhook(webhookBody, webhookHMAC, webhookSecret), "Validating the webhook should return true/false");
+        assertFalse(result, "The webhook should not be valid");
+    }
+
+    @Test
+    void testValidateWebhookBadSignatureFormat() {
+        var gh = new GitHubIntegration();
+        webhookHMAC = webhookHMAC.substring(2);
+        assertThrows(IllegalArgumentException.class, () -> gh.validateWebhook(webhookBody, webhookHMAC, webhookSecret), "The signature format should be invalid");
+    }
+
+    @Test
+    void testValidateWebhookBadSignatureEncoding() {
+        var gh = new GitHubIntegration();
+        webhookHMAC = "sha256=18af78f8f7c78b87eq";
+        assertThrows(IllegalArgumentException.class, () -> gh.validateWebhook(webhookBody, webhookHMAC, webhookSecret), "The signature encoding should be invalid");
+    }
+}


### PR DESCRIPTION
Implements a function for validating a github webhook using its body, signature header, and the webhook secret.
Closes #19 