### PR TITLE
fix/#27 Implements support for configuring JDK directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ hs_err_pid*
 target
 
 repo
+
+dduser.properties

--- a/.gitignore
+++ b/.gitignore
@@ -30,4 +30,4 @@ target
 
 repo
 
-dduser.properties
+user.properties

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Assignment2
 Assignment2
+
+## How to run
+In order to test the project, run `mvn test`
+
+In order for the maven compile and test functionalities to function correctly, one of the following actions must be taken. 
+1. Set the `JAVA_HOME` environment variable to the location of a JDK.
+2. Set the `MAVENINTGR_JAVAHOME` environment variable to the location of a JDK.
+3. Copy the `user.properties.template` to `user.properties`and set the `mavenintgr.java_home` property to the location of a JDK

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,25 @@
     <build>
             <plugins>
                 <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>properties-maven-plugin</artifactId>
+                    <version>1.0.0</version>
+                    <executions>
+                        <execution>
+                            <phase>initialize</phase>
+                            <goals>
+                                <goal>read-project-properties</goal>
+                            </goals>
+                            <configuration>
+                                <quiet>true</quiet>
+                                <files>
+                                    <file>${basedir}/user.properties</file>
+                                </files>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
@@ -62,7 +81,12 @@
                         <systemPropertyVariables>
                             <!--suppress UnresolvedMavenProperty -->
                             <maven.home>${maven.home}</maven.home>
+                            <!--suppress UnresolvedMavenProperty -->
+                            <mavenintgr.java_home>${mavenintgr.java_home}</mavenintgr.java_home>
                         </systemPropertyVariables>
+                        <environmentVariables>
+                            <MAVENINTGR_JAVAHOME>${env.MAVENINTGR_JAVAHOME}</MAVENINTGR_JAVAHOME>
+                        </environmentVariables>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/src/main/java/MavenIntegration.java
+++ b/src/main/java/MavenIntegration.java
@@ -13,7 +13,7 @@ public class MavenIntegration {
 
     /**
      * Creates a new maven instance linked to a pom.xml
-     * @param pomFile
+     * @param pomFile pom.xml file of the maven project
      */
     public MavenIntegration(String pomFile) {
         this(pomFile, getDefaultJavahome());

--- a/src/main/java/MavenIntegration.java
+++ b/src/main/java/MavenIntegration.java
@@ -9,13 +9,35 @@ import java.util.Collections;
 public class MavenIntegration {
 
     private String pomFile;
+    private String javaHome;
+
+    /**
+     * Creates a new maven instance linked to a pom.xml
+     * @param pomFile
+     */
+    public MavenIntegration(String pomFile) {
+        this(pomFile, getDefaultJavahome());
+    }
 
     /**
      * Creates a new maven instance linked to a pom.xml
      * @param pomFile pom.xml file of the maven project
+     * @param javaHome An installation directory of a JDK
      */
-    public MavenIntegration(String pomFile){
+    public MavenIntegration(String pomFile, String javaHome){
         this.pomFile = pomFile;
+        this.javaHome = javaHome;
+    }
+
+    private static String getDefaultJavahome() {
+        String javaHome = System.getProperty("mavenintgr.java_home");
+        if (javaHome == null || javaHome.equals("")) {
+            javaHome = System.getenv("MAVENINTGR_JAVAHOME");
+        }
+        if (javaHome == null || javaHome.equals("")) {
+            javaHome = System.getenv("JAVA_HOME");
+        }
+        return javaHome;
     }
 
     /**
@@ -28,6 +50,7 @@ public class MavenIntegration {
         var request = new DefaultInvocationRequest();
         var file = new File(pomFile);
         request.setPomFile(file);
+        request.setJavaHome(new File(javaHome));
         request.setGoals(Collections.singletonList("test"));
         request.setInputStream(InputStream.nullInputStream());
 

--- a/src/test/java/MavenIntegrationTest.java
+++ b/src/test/java/MavenIntegrationTest.java
@@ -1,3 +1,4 @@
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -9,9 +10,10 @@ class MavenIntegrationTest {
      */
     @Test
     void testTestTrue() {
+
         var mvn = new MavenIntegration("src/test/testprojects/valid/pom.xml");
         var result = assertDoesNotThrow(()->mvn.test(), "Test should not throw error");
-        assertFalse(result.isSuccessful(), "Test should be successful");
+        assertTrue(result.isSuccessful(), "Test should be successful");
     }
 
     /**
@@ -22,6 +24,6 @@ class MavenIntegrationTest {
         var mvn = new MavenIntegration("src/test/testprojects/testfail/pom.xml");
         var result = assertDoesNotThrow(()->mvn.test(), "Test should not throw error");
         assertFalse(result.isSuccessful(), "Test should not be successful");
-        assertFalse(result.getLog().contains("Tests run: 1, Failures: 1"), "Test should fail 1 out of 1 tests");
+        assertTrue(result.getLog().contains("Tests run: 1, Failures: 1"), "Test should fail 1 out of 1 tests");
     }
 }

--- a/src/test/testprojects/testfail/pom.xml
+++ b/src/test/testprojects/testfail/pom.xml
@@ -10,6 +10,11 @@
 
     <name>Assignment2-ValidProject</name>
 
+    <properties>
+        <maven.compiler.source>7</maven.compiler.source>
+        <maven.compiler.target>7</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -22,11 +27,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
-                </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>

--- a/src/test/testprojects/valid/pom.xml
+++ b/src/test/testprojects/valid/pom.xml
@@ -10,6 +10,11 @@
 
     <name>Assignment2-ValidProject</name>
 
+    <properties>
+        <maven.compiler.source>7</maven.compiler.source>
+        <maven.compiler.target>7</maven.compiler.target>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -22,11 +27,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
-                </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.2</version>

--- a/user.properties.template
+++ b/user.properties.template
@@ -1,0 +1,3 @@
+# Copy this file as user.properties and edit to your liking
+# JDK HOME
+mavenintgr.java_home=


### PR DESCRIPTION
Adds support for defining either
- `user.properties` file
- `MAVENINTGR_JAVAHOME` env variable
- `JAVA_HOME` env variable

to contain a path to a valid JDK installation.
Closes #27 